### PR TITLE
Extract doKick no-file rule optimization

### DIFF
--- a/ghcide/src/Development/IDE/Core/OfInterest.hs
+++ b/ghcide/src/Development/IDE/Core/OfInterest.hs
@@ -133,7 +133,13 @@ scheduleGarbageCollection state = do
     writeVar var True
 
 doKick :: Action ()
-doKick = useNoFile_ Kick
+doKick = do
+    ShakeExtras{ideTesting = IdeTesting testing} <- getShakeExtras
+    -- only kick always if testing, otherwise we rely on the kick rule
+    if testing
+      then kick
+      else void $ useNoFile Kick
+
 
 -- | Typecheck all the files of interest.
 --   Could be improved

--- a/ghcide/src/Development/IDE/Core/RuleTypes.hs
+++ b/ghcide/src/Development/IDE/Core/RuleTypes.hs
@@ -518,6 +518,14 @@ data IsFileOfInterest = IsFileOfInterest
 instance Hashable IsFileOfInterest
 instance NFData   IsFileOfInterest
 
+-- | A no-file rule that triggers the IDE "kick" action
+data Kick = Kick
+    deriving (Eq, Show, Generic)
+instance Hashable Kick
+instance NFData   Kick
+
+type instance RuleResult Kick = ()
+
 data GetModSummaryWithoutTimestamps = GetModSummaryWithoutTimestamps
     deriving (Eq, Show, Generic)
 instance Hashable GetModSummaryWithoutTimestamps

--- a/ghcide/src/Development/IDE/Main.hs
+++ b/ghcide/src/Development/IDE/Main.hs
@@ -40,7 +40,7 @@ import           Development.IDE.Core.IdeConfiguration    (IdeConfiguration (..)
                                                            modifyClientSettings,
                                                            registerIdeConfiguration)
 import           Development.IDE.Core.OfInterest          (FileOfInterestStatus (OnDisk),
-                                                           kick,
+                                                           doKick,
                                                            setFilesOfInterest)
 import           Development.IDE.Core.Rules               (mainRule)
 import qualified Development.IDE.Core.Rules               as Rules
@@ -304,7 +304,7 @@ defaultMain recorder Arguments{..} = withHeapStats (cmapWithPrio LogHeapStats re
         argsParseConfig = getConfigFromNotification argsHlsPlugins
         rules = do
             argsRules
-            unless argsDisableKick $ action kick
+            unless argsDisableKick $ action $ doKick
             pluginRules plugins
         -- install the main and ghcide-plugin rules
         -- install the kick action, which triggers a typecheck on every


### PR DESCRIPTION
Extracts the doKick portion of #29 onto current master.

Changes:
- Adds a no-file Kick rule that runs the global kick action through Shake.
- Invalidates the Kick key when files of interest are added or deleted.
- Keeps testing on the direct kick path so kick start/done notifications remain deterministic.

Validation:
- cabal build ghcide