### PR TITLE
Self-terminate after closed AIO scope refusal

### DIFF
--- a/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
@@ -327,8 +327,8 @@ The admission protocol gives every thread exactly one owner:
     'cleanupAsync'.
   - A refused thread observes the closed admission, skips its body, and finishes
     normally. It is never registered, so cleanup does not cancel it.
-  - A registered parent that observes a refused child waits at an interruptible
-    point for cleanup to cancel it. It does not cancel itself or the child.
+  - A registered parent that observes a refused child raises 'AsyncCancelled'
+    to terminate itself. Its own scope cleanup cancels any admitted siblings.
 
 This prevents either a force or rule body from escaping teardown. See
 https://github.com/haskell/haskell-language-server/issues/4985.
@@ -355,17 +355,10 @@ runAsyncIfRegistered gate io =
     if registered then Just <$> io else pure Nothing
 
 -- | Wait for a child's admission result. A refused child has finished without
--- doing work, while its already-admitted parent remains owned by cleanup and
--- must wait for that external cancellation rather than cancelling itself.
+-- doing work, so its parent terminates itself instead of waiting indefinitely
+-- for external scope cancellation.
 waitForRegisteredAsync :: Async (Maybe a) -> IO a
-waitForRegisteredAsync a = wait a >>= maybe waitForScopeCancellation pure
-
--- This loop is deliberately interruptible. In the rejected-child path the
--- current thread is already registered, so cleanup is its sole canceller.
-waitForScopeCancellation :: IO a
-waitForScopeCancellation = forever $ do
-    allowInterrupt
-    sleep 3600
+waitForRegisteredAsync a = wait a >>= maybe (throwIO AsyncCancelled) pure
 
 newtype RunInIO = RunInIO (forall a. AIO a -> IO a)
 
@@ -410,10 +403,10 @@ waitConcurrently_ many = do
         registered <- liftIO $ registerAsyncs ref (map void asyncs)
         putMVar gate registered
         return (asyncs, syncs, registered)
-    -- Refused children finish without running their forces. This parent was
-    -- already admitted, so cleanup remains its sole canceller.
+    -- Refused children finish without running their forces. Terminate this
+    -- parent immediately rather than waiting for external scope cancellation.
     if not registered
-      then liftIO $ traverse_ wait asyncs >> waitForScopeCancellation
+      then liftIO $ throwIO AsyncCancelled
       else do
         -- work on the sync computations
         liftIO $ sequence_ syncs

--- a/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
+++ b/hls-graph/src/Development/IDE/Graph/Internal/Database.hs
@@ -358,6 +358,7 @@ runAsyncIfRegistered gate io =
 -- doing work, so its parent terminates itself instead of waiting indefinitely
 -- for external scope cancellation.
 waitForRegisteredAsync :: Async (Maybe a) -> IO a
+-- Raising here lets 'runAIO' perform the parent's ordinary exception cleanup.
 waitForRegisteredAsync a = wait a >>= maybe (throwIO AsyncCancelled) pure
 
 newtype RunInIO = RunInIO (forall a. AIO a -> IO a)

--- a/hls-graph/test/ActionSpec.hs
+++ b/hls-graph/test/ActionSpec.hs
@@ -1,17 +1,26 @@
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module ActionSpec where
 
 import           Control.Concurrent                      (MVar, newEmptyMVar,
                                                           readMVar)
 import qualified Control.Concurrent                      as C
-import           Control.Concurrent.Async                (cancel, withAsync)
+import           Control.Concurrent.Async                (AsyncCancelled,
+                                                          cancel, waitCatch,
+                                                          withAsync)
 import           Control.Concurrent.STM
-import           Control.Exception                       (finally)
+import           Control.Exception                       (finally,
+                                                          fromException)
+import           Control.Monad                           (void)
 import           Control.Monad.IO.Class                  (MonadIO (..))
 import           Data.Maybe                              (isJust, isNothing)
-import           Development.IDE.Graph                   (shakeOptions)
+import           Development.IDE.Graph                   (RuleResult,
+                                                          shakeOptions)
+import           Development.IDE.Graph.Classes           (Hashable, NFData)
 import           Development.IDE.Graph.Database          (shakeNewDatabase,
                                                           shakeRunDatabase,
                                                           shakeRunDatabaseForKeys)
@@ -20,6 +29,7 @@ import           Development.IDE.Graph.Internal.Key
 import           Development.IDE.Graph.Internal.Types
 import           Development.IDE.Graph.Rule
 import           Example
+import           GHC.Generics                            (Generic)
 import qualified StmContainers.Map                       as STM
 import           System.IO.Unsafe                        (unsafePerformIO)
 import           System.Timeout                          (timeout)
@@ -29,11 +39,23 @@ import           Test.Hspec
 -- Park traversal after the preceding key has been handled. The test releases
 -- this key normally; cancellation never crosses this unsafe test-only barrier.
 {-# NOINLINE blockSecondKey #-}
-blockSecondKey :: MVar () -> MVar () -> Rule ()
-blockSecondKey reached release = unsafePerformIO $ do
+blockSecondKey :: MVar () -> MVar () -> a -> a
+blockSecondKey reached release value = unsafePerformIO $ do
   C.putMVar reached ()
   C.takeMVar release
-  pure Rule
+  pure value
+
+data ScopeRule = ScopeParent | ScopeLeft | ScopeRight
+  deriving (Eq, Show, Generic, Hashable, NFData)
+
+type instance RuleResult ScopeRule = ()
+
+scopeRules :: Rules ()
+scopeRules = addRule $ \key _old _mode -> do
+  case key of
+    ScopeParent -> void $ apply [ScopeLeft, ScopeRight]
+    _           -> pure ()
+  pure $ RunResult ChangedRecomputeDiff "" () (pure ())
 
 
 spec :: Spec
@@ -145,7 +167,7 @@ spec = do
     Just (Clean res) <- lookup (newKey theKey) <$> getDatabaseValues theDb
     resultDeps res `shouldBe` UnknownDeps
 
-  describe "Closing escaped rule computations" $
+  describe "Closing escaped rule computations" $ do
     it "does not leave a late async alive outside its closed AIO scope" $ do
       bodyStarted <- newEmptyMVar
       releaseBody <- newEmptyMVar
@@ -172,7 +194,7 @@ spec = do
         releaseSecondKey <- newEmptyMVar
         withAsync
           (build theDb emptyStack
-            [Rule @(), blockSecondKey reachedSecondKey releaseSecondKey]) $ \secondBuild -> do
+            [Rule @(), blockSecondKey reachedSecondKey releaseSecondKey (Rule @())]) $ \secondBuild -> do
               C.takeMVar reachedSecondKey
               -- Close the force's original scope before the already-running
               -- second build proceeds to force what it selected.
@@ -192,3 +214,39 @@ spec = do
                   C.takeMVar bodyFinished
                 _ -> pure ()
               outOfScopeAlive `shouldBe` False
+
+    it "self-terminates when nested work observes its AIO scope is closed" $ do
+      ShakeDatabase _ _ theDb@Database{..} <-
+        shakeNewDatabase shakeOptions scopeRules
+      -- Give the parent two recorded dependencies so refreshing it takes the
+      -- multi-spawn admission path.
+      void $ build theDb emptyStack [ScopeParent]
+      incDatabase theDb Nothing
+
+      -- Publish a lazy refresh tied to this first build's AIO scope.
+      withAsync (build theDb emptyStack $ repeat ScopeParent) $ \firstBuild -> do
+        atomically $ do
+          details <- STM.lookup (newKey ScopeParent) databaseValues
+          case details of
+            Just KeyDetails{keyStatus = Running{}} -> pure ()
+            _                                      -> retry
+
+        reachedSecondKey <- newEmptyMVar
+        releaseSecondKey <- newEmptyMVar
+        withAsync
+          (build theDb emptyStack
+            [ ScopeParent
+            , blockSecondKey reachedSecondKey releaseSecondKey ScopeLeft
+            ]) $ \secondBuild -> do
+              C.takeMVar reachedSecondKey
+              cancel firstBuild
+              C.putMVar releaseSecondKey ()
+              secondResult <- timeout 1000000 $ waitCatch secondBuild
+              -- Cleanup only matters for the old waiting behavior; the fixed
+              -- build has already raised 'AsyncCancelled' in its own thread.
+              cancel secondBuild
+              let selfTerminated = case secondResult of
+                    Just (Left err) ->
+                      isJust (fromException err :: Maybe AsyncCancelled)
+                    _ -> False
+              selfTerminated `shouldBe` True


### PR DESCRIPTION
Stacked on #38.

## Summary

- raise `AsyncCancelled` when a registered parent observes that a child was refused by a closed AIO scope
- raise immediately when batch registration itself observes the closed scope
- remove the interruptible sleep loop that waited for external cancellation
- cover the nested refresh path that actually reaches closed-scope admission after PR #38's later inline-refresh changes

## Why

PR #38 prevents refused children from starting their rule bodies, but the parent currently parks in `waitForScopeCancellation` until another thread cancels it. Once the parent has observed that its captured scope is closed, it can terminate itself immediately. Throwing `AsyncCancelled` also runs that parent's normal AIO exception cleanup, which cancels any admitted sibling work it still owns.

## Regression

The new test first records two dependencies for a parent key, then publishes a lazy refresh tied to one build's AIO scope. A second build selects that refresh before the first scope closes and forces it afterward. The nested multi-spawn observes the closed scope, and the test requires the second build to finish by raising `AsyncCancelled` without external cancellation.

## Validation

- `cabal test hls-graph:test:tests -fpedantic --test-show-details=direct --test-option=-p --test-option='/self-terminates when nested work/'`
- `cabal test hls-graph:test:tests -fpedantic --test-show-details=direct`
- all 12 `hls-graph` tests passed
- `stylish-haskell` pre-commit hook passed
- `git diff --check`
