### PR TITLE
Add upstream benchmark observer runner

### DIFF
--- a/.github/workflows/upstream-benchmark-observer.yml
+++ b/.github/workflows/upstream-benchmark-observer.yml
@@ -1,0 +1,247 @@
+name: Upstream Benchmark Observer
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: Upstream HLS branch, tag, or full commit SHA to measure
+        required: true
+        default: master
+        type: string
+      observer_repository:
+        description: Optional OWNER/REPO to notify with benchmark-complete
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-benchmark-${{ inputs.upstream_ref }}
+  cancel-in-progress: false
+
+env:
+  UPSTREAM_REPOSITORY: haskell/haskell-language-server
+
+jobs:
+  resolve:
+    name: Resolve upstream ref
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.UPSTREAM_REPOSITORY }}
+          ref: ${{ inputs.upstream_ref }}
+          fetch-depth: 1
+      - id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  bench_init:
+    name: Prepare GHC ${{ matrix.ghc }} benchmark workspace
+    needs: resolve
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.12', '9.14']
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ env.UPSTREAM_REPOSITORY }}
+          ref: ${{ needs.resolve.outputs.commit }}
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-build
+        with:
+          ghc: ${{ matrix.ghc }}
+          os: ${{ runner.os }}
+          shorten-hls: 'false'
+
+      - name: Check out observer tooling
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          path: .observer-harness
+          sparse-checkout: bench/observer
+
+      - name: Create exact-SHA observer config
+        run: >-
+          python3 .observer-harness/bench/observer/make_config.py
+          bench/config.yaml bench/observer-config.yaml
+
+      - name: Build benchmark driver
+        run: |
+          cabal configure --enable-benchmarks --max-backjumps 12000
+          cabal build haskell-language-server:benchmark
+
+      - name: Build measured HLS binary
+        run: >-
+          cabal bench -j
+          --benchmark-options="--config bench/observer-config.yaml all-binaries"
+
+      - name: Package workspace
+        run: tar -czf workspace.tar.gz * .git
+
+      - name: Package Cabal home
+        run: |
+          cd ~/.cabal
+          tar -czf cabal.tar.gz *
+
+      - name: Upload workspace
+        uses: actions/upload-artifact@v7
+        with:
+          name: observer-workspace-${{ matrix.ghc }}
+          retention-days: 1
+          path: workspace.tar.gz
+
+      - name: Upload Cabal home
+        uses: actions/upload-artifact@v7
+        with:
+          name: observer-cabal-home-${{ matrix.ghc }}
+          retention-days: 1
+          path: ~/.cabal/cabal.tar.gz
+
+  benchmark:
+    name: GHC ${{ matrix.ghc }} / ${{ matrix.example }}
+    needs: [resolve, bench_init]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['9.12', '9.14']
+        cabal: ['3.16']
+        example: [cabal, lsp-types]
+    steps:
+      - uses: haskell-actions/setup@v2.11
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+          enable-stack: false
+
+      - name: Download Cabal home
+        uses: actions/download-artifact@v8
+        with:
+          name: observer-cabal-home-${{ matrix.ghc }}
+          path: .
+
+      - name: Download workspace
+        uses: actions/download-artifact@v8
+        with:
+          name: observer-workspace-${{ matrix.ghc }}
+          path: .
+
+      - name: Restore workspace
+        run: |
+          mkdir -p ~/.cabal
+          tar xzf workspace.tar.gz
+          tar xzf cabal.tar.gz --directory ~/.cabal
+
+      - name: Check out observer tooling
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          path: .observer-harness
+          sparse-checkout: bench/observer
+
+      - name: Run benchmark
+        run: >-
+          cabal bench -j
+          --benchmark-options="--config bench/observer-config.yaml ${{ matrix.example }}"
+
+      - name: Export observer artifact
+        env:
+          ARTIFACT_NAME: observer-benchmark-${{ matrix.example }}-ghc-${{ matrix.ghc }}
+          UPSTREAM_COMMIT: ${{ needs.resolve.outputs.commit }}
+          UPSTREAM_REF: ${{ inputs.upstream_ref }}
+        run: |
+          mkdir -p observer-artifact
+          cp "bench-results/unprofiled/${{ matrix.example }}/results.csv" observer-artifact/results.csv
+          cp "bench-results/unprofiled/${{ matrix.example }}/resultDiff.csv" observer-artifact/resultDiff.csv
+          python3 .observer-harness/bench/observer/export_result.py \
+            --results observer-artifact/results.csv \
+            --output observer-artifact/benchmark.json \
+            --upstream-repository "$UPSTREAM_REPOSITORY" \
+            --upstream-ref "$UPSTREAM_REF" \
+            --upstream-commit "$UPSTREAM_COMMIT" \
+            --workflow-repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --artifact-name "$ARTIFACT_NAME" \
+            --ghc "${{ matrix.ghc }}" \
+            --example "${{ matrix.example }}" \
+            --runner-os "$RUNNER_OS" \
+            --runner-arch "$RUNNER_ARCH" \
+            --runner-image "${ImageOS:-unknown}" \
+            --runner-image-version "${ImageVersion:-unknown}"
+
+      - name: Upload observer result
+        uses: actions/upload-artifact@v7
+        with:
+          name: observer-benchmark-${{ matrix.example }}-ghc-${{ matrix.ghc }}
+          retention-days: 30
+          path: observer-artifact
+
+      - name: Package benchmark logs
+        if: always()
+        run: |
+          find bench-results -type f \( -name '*.log' -o -name '*.hp' \) -print0 \
+            | tar --null -T - -czf benchmark-logs.tar.gz
+
+      - name: Upload benchmark logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: observer-logs-${{ matrix.example }}-ghc-${{ matrix.ghc }}
+          retention-days: 14
+          path: benchmark-logs.tar.gz
+
+  notify:
+    name: Notify observer repository
+    needs: [resolve, bench_init, benchmark]
+    if: ${{ needs.benchmark.result == 'success' && inputs.observer_repository != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch benchmark-complete
+        env:
+          GH_TOKEN: ${{ secrets.OBSERVER_TOKEN }}
+          OBSERVER_REPOSITORY: ${{ inputs.observer_repository }}
+          UPSTREAM_COMMIT: ${{ needs.resolve.outputs.commit }}
+          UPSTREAM_REF: ${{ inputs.upstream_ref }}
+        run: |
+          test -n "$GH_TOKEN" || {
+            echo 'OBSERVER_TOKEN is required when observer_repository is set' >&2
+            exit 1
+          }
+          [[ "$OBSERVER_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+            echo 'observer_repository must have OWNER/REPO form' >&2
+            exit 1
+          }
+          jq -n \
+            --arg benchmark_repository "$GITHUB_REPOSITORY" \
+            --argjson run_id "$GITHUB_RUN_ID" \
+            --argjson run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg upstream_repository "$UPSTREAM_REPOSITORY" \
+            --arg upstream_ref "$UPSTREAM_REF" \
+            --arg upstream_commit "$UPSTREAM_COMMIT" \
+            '{
+              event_type: "benchmark-complete",
+              client_payload: {
+                benchmark_repository: $benchmark_repository,
+                run_id: $run_id,
+                run_attempt: $run_attempt,
+                upstream_repository: $upstream_repository,
+                upstream_ref: $upstream_ref,
+                upstream_commit: $upstream_commit,
+                expected_artifacts: 4
+              }
+            }' \
+            | gh api --method POST "repos/$OBSERVER_REPOSITORY/dispatches" --input -

--- a/bench/observer/README.md
+++ b/bench/observer/README.md
@@ -1,0 +1,11 @@
+# Upstream benchmark observer tooling
+
+`upstream-benchmark-observer.yml` turns this fork into a stateless benchmark runner. It checks out an exact commit from `haskell/haskell-language-server`, rewrites the temporary benchmark config to measure only that `HEAD`, runs the Cabal and lsp-types workloads under GHC 9.12 and 9.14, and uploads one normalized JSON artifact per matrix coordinate.
+
+If `observer_repository` is supplied to `workflow_dispatch`, the final job sends `benchmark-complete` only after all four artifacts have uploaded successfully. The dispatch payload includes the exact upstream SHA and workflow run identity. Configure `OBSERVER_TOKEN` with **Contents: write** access to the observer repository to enable that callback.
+
+Local tooling tests:
+
+```bash
+python3 -m unittest discover -s bench/observer -p 'test_*.py' -v
+```

--- a/bench/observer/export_result.py
+++ b/bench/observer/export_result.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Convert one HLS benchmark matrix result into a versioned JSON artifact."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+MEMORY = re.compile(r"^(-?[0-9]+(?:\.[0-9]+)?)MB$")
+
+FIELD_NAMES = {
+    "Version": "version",
+    "Configuration": "configuration",
+    "name": "benchmark",
+    "success": "success",
+    "samples": "samples",
+    "startup": "startup_ms",
+    "setup": "setup_ms",
+    "userT": "user_time_ms",
+    "delayedT": "delayed_time_ms",
+    "1stBuildT": "first_build_ms",
+    "avgPerRespT": "average_response_ms",
+    "totalT": "total_time_ms",
+    "rulesBuilt": "rules_built",
+    "rulesChanged": "rules_changed",
+    "rulesVisited": "rules_visited",
+    "rulesTotal": "rules_total",
+    "ruleEdges": "rule_edges",
+    "ghcRebuilds": "ghc_rebuilds",
+    "maxResidency": "max_residency_mb",
+    "allocatedBytes": "allocated_mb",
+}
+
+INTEGER_FIELDS = {
+    "samples",
+    "rules_built",
+    "rules_changed",
+    "rules_visited",
+    "rules_total",
+    "rule_edges",
+    "ghc_rebuilds",
+}
+FLOAT_FIELDS = {
+    "startup_ms",
+    "setup_ms",
+    "user_time_ms",
+    "delayed_time_ms",
+    "first_build_ms",
+    "average_response_ms",
+    "total_time_ms",
+}
+MEMORY_FIELDS = {"max_residency_mb", "allocated_mb"}
+
+
+def parse_timestamp(value: str) -> str:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include a UTC offset")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_value(field: str, value: str) -> Any:
+    if field == "success":
+        if value not in {"True", "False"}:
+            raise ValueError(f"invalid success value: {value!r}")
+        return value == "True"
+    if field in INTEGER_FIELDS:
+        return int(value)
+    if field in FLOAT_FIELDS:
+        return float(value)
+    if field in MEMORY_FIELDS:
+        match = MEMORY.fullmatch(value)
+        if match is None:
+            raise ValueError(f"invalid memory value for {field}: {value!r}")
+        return float(match.group(1))
+    return value
+
+
+def read_results(path: Path) -> list[dict[str, Any]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle, skipinitialspace=True)
+        headers = [header.strip() for header in (reader.fieldnames or [])]
+        missing = sorted(set(FIELD_NAMES) - set(headers))
+        if missing:
+            raise ValueError(f"benchmark CSV is missing columns: {', '.join(missing)}")
+
+        results: list[dict[str, Any]] = []
+        for raw_row in reader:
+            row = {(key or "").strip(): (value or "").strip() for key, value in raw_row.items()}
+            converted = {
+                FIELD_NAMES[source]: parse_value(FIELD_NAMES[source], row[source])
+                for source in FIELD_NAMES
+            }
+            if converted["version"] != "HEAD":
+                raise ValueError(f"observer result must describe HEAD, got {converted['version']!r}")
+            results.append(converted)
+
+    if not results:
+        raise ValueError("benchmark CSV contains no result rows")
+    return results
+
+
+def repository(value: str) -> str:
+    if REPOSITORY.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError("repository must have OWNER/REPO form")
+    return value
+
+
+def commit(value: str) -> str:
+    value = value.lower()
+    if COMMIT.fullmatch(value) is None:
+        raise argparse.ArgumentTypeError("commit must be a full 40-character SHA")
+    return value
+
+
+def arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--upstream-repository", required=True, type=repository)
+    parser.add_argument("--upstream-ref", required=True)
+    parser.add_argument("--upstream-commit", required=True, type=commit)
+    parser.add_argument("--workflow-repository", required=True, type=repository)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--run-attempt", required=True, type=int)
+    parser.add_argument("--artifact-name", required=True)
+    parser.add_argument("--ghc", required=True)
+    parser.add_argument("--example", required=True)
+    parser.add_argument("--runner-os", required=True)
+    parser.add_argument("--runner-arch", required=True)
+    parser.add_argument("--runner-image", default="unknown")
+    parser.add_argument("--runner-image-version", default="unknown")
+    parser.add_argument(
+        "--measured-at",
+        default=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = arguments()
+    results = read_results(args.results)
+    successful = sum(result["success"] for result in results)
+    workflow_url = f"https://github.com/{args.workflow_repository}/actions/runs/{args.run_id}"
+    commit_url = f"https://github.com/{args.upstream_repository}/commit/{args.upstream_commit}"
+
+    document = {
+        "schema_version": 1,
+        "upstream": {
+            "repository": args.upstream_repository,
+            "ref": args.upstream_ref,
+            "commit": args.upstream_commit,
+            "commit_url": commit_url,
+        },
+        "workflow": {
+            "repository": args.workflow_repository,
+            "run_id": args.run_id,
+            "run_attempt": args.run_attempt,
+            "run_url": workflow_url,
+            "artifact_name": args.artifact_name,
+        },
+        "measurement": {
+            "timestamp": parse_timestamp(args.measured_at),
+            "ghc": args.ghc,
+            "example": args.example,
+            "runner": {
+                "os": args.runner_os,
+                "arch": args.runner_arch,
+                "image": args.runner_image,
+                "image_version": args.runner_image_version,
+            },
+        },
+        "summary": {
+            "successful_cases": successful,
+            "total_cases": len(results),
+        },
+        "results": results,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/observer/make_config.py
+++ b/bench/observer/make_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Create a benchmark config that measures only the checked-out HEAD."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+TOP_LEVEL_KEY = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*:\s*(?:#.*)?$")
+
+
+def head_only_config(source: str) -> str:
+    """Replace the top-level versions section without requiring PyYAML."""
+    lines = source.splitlines(keepends=True)
+    starts = [index for index, line in enumerate(lines) if line.rstrip() == "versions:"]
+    if len(starts) != 1:
+        raise ValueError(f"expected exactly one top-level versions section, found {len(starts)}")
+
+    start = starts[0]
+    end = next(
+        (
+            index
+            for index in range(start + 1, len(lines))
+            if TOP_LEVEL_KEY.fullmatch(lines[index].rstrip("\r\n"))
+        ),
+        None,
+    )
+    if end is None:
+        raise ValueError("versions must be followed by another top-level config key")
+
+    newline = "\r\n" if lines[start].endswith("\r\n") else "\n"
+    return "".join(lines[:start] + [f"versions:{newline}", f"- HEAD{newline}", newline] + lines[end:])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    rendered = head_only_config(args.source.read_text(encoding="utf-8"))
+    args.output.write_text(rendered, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/observer/test_observer_tools.py
+++ b/bench/observer/test_observer_tools.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from export_result import read_results
+from make_config import head_only_config
+
+
+HERE = Path(__file__).parent
+
+
+class MakeConfigTests(unittest.TestCase):
+    def test_replaces_only_the_versions_section(self) -> None:
+        source = """samples: 50
+versions:
+# examples
+- upstream: origin/master
+- HEAD
+
+# plugin selection
+configurations:
+- All: []
+"""
+        self.assertEqual(
+            head_only_config(source),
+            """samples: 50
+versions:
+- HEAD
+
+configurations:
+- All: []
+""",
+        )
+
+    def test_rejects_missing_versions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            head_only_config("samples: 50\nconfigurations: []\n")
+
+
+class ExportResultTests(unittest.TestCase):
+    CSV = """Version, Configuration, name, success, samples, startup, setup, userT, delayedT, 1stBuildT, avgPerRespT, totalT, rulesBuilt, rulesChanged, rulesVisited, rulesTotal, ruleEdges, ghcRebuilds, maxResidency, allocatedBytes
+HEAD, All, hover, True, 50, 712.50, 1.00, 4.00, 2.00, 3.00, 0.50, 20.00, 1, 2, 3, 4, 5, 6, 421MB, 900MB
+"""
+
+    def test_reads_typed_result_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory, "results.csv")
+            path.write_text(self.CSV, encoding="utf-8")
+            rows = read_results(path)
+
+        self.assertEqual(rows[0]["benchmark"], "hover")
+        self.assertEqual(rows[0]["startup_ms"], 712.5)
+        self.assertEqual(rows[0]["max_residency_mb"], 421.0)
+        self.assertTrue(rows[0]["success"])
+
+    def test_cli_writes_versioned_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory, "results.csv")
+            output = Path(directory, "benchmark.json")
+            source.write_text(self.CSV, encoding="utf-8")
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(HERE / "export_result.py"),
+                    "--results",
+                    str(source),
+                    "--output",
+                    str(output),
+                    "--upstream-repository",
+                    "haskell/haskell-language-server",
+                    "--upstream-ref",
+                    "master",
+                    "--upstream-commit",
+                    "a" * 40,
+                    "--workflow-repository",
+                    "soulomoon/haskell-language-server",
+                    "--run-id",
+                    "123",
+                    "--run-attempt",
+                    "1",
+                    "--artifact-name",
+                    "observer-benchmark-cabal-ghc-9.14",
+                    "--ghc",
+                    "9.14",
+                    "--example",
+                    "cabal",
+                    "--runner-os",
+                    "Linux",
+                    "--runner-arch",
+                    "X64",
+                    "--measured-at",
+                    "2026-08-13T04:00:00Z",
+                ],
+                check=True,
+            )
+            document = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(document["schema_version"], 1)
+        self.assertEqual(document["upstream"]["commit"], "a" * 40)
+        self.assertEqual(document["summary"], {"successful_cases": 1, "total_cases": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an exact-SHA upstream HLS benchmark workflow
- export normalized JSON metadata for each GHC/example matrix entry
- notify the observer repository only after the complete matrix succeeds

## Validation

- 4 Python unit tests
- actionlint and Bash/YAML syntax checks
- end-to-end conversion of all four artifacts from Actions run 31567976434
